### PR TITLE
fix(norminette): Fixes error where require('lint').linters_by_ft.{c,cpp} is not defined

### DIFF
--- a/lua/ft_nvim/norminette/init.lua
+++ b/lua/ft_nvim/norminette/init.lua
@@ -67,8 +67,10 @@ local function setup_nvim_lint(opts)
 			return true
 		end,
 	}
-	table.insert(lint.linters_by_ft.c, "norminette")
-	table.insert(lint.linters_by_ft.cpp, "norminette")
+	vim.tbl_deep_extend("force", lint.linters_by_ft, {
+		c = { "norminette" },
+		cpp = { "norminette" },
+	})
 end
 
 return {


### PR DESCRIPTION
Fixes issue where registering norminette source would fail due to
`require'lint'.linters_by_ft` not having entries for `c` and `cpp` filetypes.
