### PR TITLE
fix(docs): add missing "d" to `enabled` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ require("ft_nvim").setup({
 	-- Configures the 42 Header integration
 	header = {
 		-- Enable the 42 Header integration (default: true).
-		enable = true,
+		enabled = true,
 		-- Your Intranet username (default: "marvin").
 		username = "marvin",
 		-- Your Intranet email (default: "marvin@42.fr").
@@ -69,7 +69,7 @@ require("ft_nvim").setup({
 	-- Configures the norminette integration.
 	norminette = {
 		-- Enable the norminette integration (default: true).
-		enable = true,
+		enabled = true,
 		-- The command to run norminette (default: "norminette").
 		cmd = "norminette",
 		-- A function to conditionally enable the norminette integration (default: nil)


### PR DESCRIPTION
Setting `header.enable` or `norminette.enable` to `false` does nothing.