### PR TITLE
refactor(nix): use `buildVimPlugin`, add metadata

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,9 +24,7 @@
       };
     });
     packages = forEachSystem ({pkgs}: {
-      ft_nvim = import ./nix/pkgs/ft_nvim.nix {
-        stdenv = pkgs.stdenvNoCC;
-      };
+      ft_nvim = pkgs.callPackage ./nix/pkgs/ft_nvim.nix {inherit self;};
     });
     overlays = {
       default = final: _: {

--- a/nix/pkgs/ft_nvim.nix
+++ b/nix/pkgs/ft_nvim.nix
@@ -1,9 +1,15 @@
-{stdenv}:
-stdenv.mkDerivation {
-  name = "ft_nvim";
+{
+  self,
+  lib,
+  vimUtils,
+}:
+vimUtils.buildVimPlugin {
+  pname = "ft_nvim";
+  version = self.rev or self.dirtyRev or "unknown";
   src = ../..;
-  installPhase = ''
-    mkdir -p $out
-    cp -r $src/* $out/
-  '';
+  meta = {
+    description = "A Neovim plugin for École 42";
+    homepage = "https://github.com/vinicius507/ft_nvim";
+    license = lib.licenses.mit;
+  };
 }


### PR DESCRIPTION
Hello,

This PR changes the Nix derivation to use the standard `vimUtils.buildVimPlugin` builder and adds metadata, which can be useful for some modules.