### PR TITLE
fix: remove deprecated `pkgs.system`, update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719848872,
-        "narHash": "sha256-H3+EC5cYuq+gQW8y0lSrrDZfH71LB4DAf+TDFyvwCNA=",
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "00d80d13810dbfea8ab4ed1009b09100cca86ba8",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,12 +17,6 @@
           };
         });
   in {
-    lib = forEachSystem ({pkgs}: {
-      inherit forEachSystem;
-      mkShell = pkgs.mkShell.override {
-        inherit (pkgs.llvmPackages_12) stdenv;
-      };
-    });
     packages = forEachSystem ({pkgs}: {
       ft_nvim = import ./nix/pkgs/ft_nvim.nix {
         stdenv = pkgs.stdenvNoCC;
@@ -34,7 +28,7 @@
       };
     };
     devShells = forEachSystem ({pkgs}: {
-      default = self.lib.${pkgs.stdenv.hostPlatform.system}.mkShell {
+      default = pkgs.mkShell {
         packages = with pkgs; [
           norminette
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -30,11 +30,11 @@
     });
     overlays = {
       default = final: _: {
-        ft_nvim = self.packages.${final.system}.ft_nvim;
+        inherit (self.packages.${final.stdenv.hostPlatform.system}) ft_nvim;
       };
     };
     devShells = forEachSystem ({pkgs}: {
-      default = self.lib.${pkgs.system}.mkShell {
+      default = self.lib.${pkgs.stdenv.hostPlatform.system}.mkShell {
         packages = with pkgs; [
           norminette
         ];


### PR DESCRIPTION
Hello,

`pkgs.system` has been deprecated since [nixpkgs#456527](https://github.com/NixOS/nixpkgs/pull/456527),  using this flake's overlay on an up-to-date Nix system shows the following warning:
```
evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
```